### PR TITLE
Move load dotenv before the call of validation

### DIFF
--- a/public/wp-config.php
+++ b/public/wp-config.php
@@ -11,9 +11,9 @@ if ( file_exists( __DIR__ . '/../vendor/autoload.php' ) ) {
 }
 
 $dotenv = Dotenv::createImmutable( __DIR__ . '/../' );
+$dotenv->load();
 $dotenv->required( [ 'WPC_DB_HOST', 'WPC_DB_NAME', 'WPC_DB_USER', 'WPC_DB_PASSWORD' ] );
 $dotenv->ifPresent( 'ALLOW_INSECURE' )->isBoolean();
-$dotenv->load();
 unset( $dotenv );
 
 collect( $_ENV )->keys()


### PR DESCRIPTION
Hey @johnpbloch,

I playaround with your project and I realised that the dotenv loading is corrupt :)

**Further infos**

* https://github.com/johnpbloch/wordpress-project/issues/5
* https://github.com/vlucas/phpdotenv/issues/524